### PR TITLE
Fix Workers not initializing

### DIFF
--- a/libraries/image/build.gradle.kts
+++ b/libraries/image/build.gradle.kts
@@ -41,6 +41,7 @@ dependencies {
     // Dagger
     implementation(Google.dagger.hilt.android)
     kapt(Google.dagger.hilt.compiler)
+    kapt(AndroidX.hilt.compiler)
 
     // Other
     implementation(JakeWharton.timber)

--- a/libraries/submission/build.gradle.kts
+++ b/libraries/submission/build.gradle.kts
@@ -41,6 +41,7 @@ dependencies {
     // Dagger
     implementation(Google.dagger.hilt.android)
     kapt(Google.dagger.hilt.compiler)
+    kapt(AndroidX.hilt.compiler)
 
     // Other
     implementation(JakeWharton.timber)


### PR DESCRIPTION
This PR fixes an issue which prevented WorkManager Workers to be initilaized. The issue was caused by the removal of the AndroidX Hilt compiler dependency during #61 