### PR TITLE
Improve handling of ignored scrobble submissions

### DIFF
--- a/app/schemas/de.schnettler.scrobbler.db.AppDatabase/53.json
+++ b/app/schemas/de.schnettler.scrobbler.db.AppDatabase/53.json
@@ -2,7 +2,7 @@
   "formatVersion": 1,
   "database": {
     "version": 53,
-    "identityHash": "26f0675c46a6ec6b3591885e9f1c4213",
+    "identityHash": "93a555d775ad6a0691ff4594da3fd930",
     "entities": [
       {
         "tableName": "sessions",
@@ -526,12 +526,44 @@
         },
         "indices": [],
         "foreignKeys": []
+      },
+      {
+        "tableName": "SubmissionFailureEntity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`timestamp` INTEGER NOT NULL, `failureCode` INTEGER NOT NULL, `failureReason` TEXT NOT NULL, PRIMARY KEY(`timestamp`))",
+        "fields": [
+          {
+            "fieldPath": "timestamp",
+            "columnName": "timestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "failureCode",
+            "columnName": "failureCode",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "failureReason",
+            "columnName": "failureReason",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "timestamp"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
       }
     ],
     "views": [],
     "setupQueries": [
       "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
-      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '26f0675c46a6ec6b3591885e9f1c4213')"
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '93a555d775ad6a0691ff4594da3fd930')"
     ]
   }
 }

--- a/app/src/main/java/de/schnettler/scrobbler/db/AppDatabase.kt
+++ b/app/src/main/java/de/schnettler/scrobbler/db/AppDatabase.kt
@@ -31,7 +31,9 @@ import de.schnettler.scrobbler.persistence.dao.ArtistDao
 import de.schnettler.scrobbler.persistence.dao.TrackDao
 import de.schnettler.scrobbler.profile.db.ToplistDao
 import de.schnettler.scrobbler.profile.db.UserDao
+import de.schnettler.scrobbler.submission.db.SubmissionFailureDao
 import de.schnettler.scrobbler.submission.domain.SubmissionDao
+import de.schnettler.scrobbler.submission.model.SubmissionFailureEntity
 import dev.matrix.roomigrant.GenerateRoomMigrations
 
 @Database(
@@ -46,8 +48,9 @@ import dev.matrix.roomigrant.GenerateRoomMigrations
         Scrobble::class,
         RelatedArtistEntry::class,
         Stats::class,
-        EntityInfo::class
-    ], version = 53
+        EntityInfo::class,
+        SubmissionFailureEntity::class
+    ], version = 55
 )
 @Suppress("TooManyFunctions")
 @TypeConverters(TypeConverter::class)
@@ -72,6 +75,7 @@ abstract class AppDatabase : RoomDatabase() {
     abstract fun historyDao(): HistoryDao
     abstract fun imageDao(): ImageDao
     abstract fun toplistDao(): ToplistDao
+    abstract fun submissionFailureDao(): SubmissionFailureDao
 }
 
 @Suppress("SpreadOperator")

--- a/app/src/main/java/de/schnettler/scrobbler/di/DatabaseModule.kt
+++ b/app/src/main/java/de/schnettler/scrobbler/di/DatabaseModule.kt
@@ -23,6 +23,7 @@ import de.schnettler.scrobbler.persistence.dao.ArtistDao
 import de.schnettler.scrobbler.persistence.dao.TrackDao
 import de.schnettler.scrobbler.profile.db.ToplistDao
 import de.schnettler.scrobbler.profile.db.UserDao
+import de.schnettler.scrobbler.submission.db.SubmissionFailureDao
 import de.schnettler.scrobbler.submission.domain.SubmissionDao
 import javax.inject.Singleton
 
@@ -101,4 +102,8 @@ class DatabaseModule {
     @Provides
     @Singleton
     fun provideToplistDao(database: AppDatabase): ToplistDao = database.toplistDao()
+
+    @Provides
+    @Singleton
+    fun provideSubmissionFailureDao(database: AppDatabase): SubmissionFailureDao = database.submissionFailureDao()
 }

--- a/features/history/src/main/java/de/schnettler/scrobbler/history/domain/HistoryDao.kt
+++ b/features/history/src/main/java/de/schnettler/scrobbler/history/domain/HistoryDao.kt
@@ -14,8 +14,8 @@ abstract class HistoryDao : BaseDao<Scrobble> {
         limit: Int = 50
     ): Flow<List<Scrobble>>
 
-    @Query("SELECT COUNT(timestamp) FROM localTracks WHERE status = :status")
-    abstract fun getNumberOfCachedScrobbles(status: ScrobbleStatus = ScrobbleStatus.LOCAL): Flow<Int>
+    @Query("SELECT COUNT(timestamp) FROM localTracks WHERE status = 'LOCAL'")
+    abstract fun getNumberOfCachedScrobbles(): Flow<Int>
 
     @Query("DELETE FROM localTracks WHERE status = :include")
     abstract fun deleteByStatus(include: ScrobbleStatus = ScrobbleStatus.PLAYING)

--- a/features/history/src/main/java/de/schnettler/scrobbler/history/domain/LocalRepository.kt
+++ b/features/history/src/main/java/de/schnettler/scrobbler/history/domain/LocalRepository.kt
@@ -7,10 +7,12 @@ import de.schnettler.scrobbler.core.map.forLists
 import de.schnettler.scrobbler.history.api.HistoryApi
 import de.schnettler.scrobbler.model.Scrobble
 import de.schnettler.scrobbler.model.ScrobbleStatus
+import de.schnettler.scrobbler.submission.db.SubmissionFailureDao
 import javax.inject.Inject
 
 class LocalRepository @Inject constructor(
     private val historyDao: HistoryDao,
+    private val submissionFailureDao: SubmissionFailureDao,
     private val historyApi: HistoryApi
 ) {
     val recentTracksStore = StoreBuilder.from(
@@ -33,6 +35,8 @@ class LocalRepository @Inject constructor(
     ).build()
 
     fun getNumberOfCachedScrobbles() = historyDao.getNumberOfCachedScrobbles()
+
+    fun getNumberOfIgnoredScrobbles() = submissionFailureDao.getNumberOfIgnoredScrobbles()
 
     suspend fun getScrobblesById(ids: List<Long>) = historyDao.getScrobblesWithTimestamp(ids)
 }

--- a/features/history/src/main/java/de/schnettler/scrobbler/history/ui/HistoryScreen.kt
+++ b/features/history/src/main/java/de/schnettler/scrobbler/history/ui/HistoryScreen.kt
@@ -19,6 +19,7 @@ import androidx.compose.material.ListItem
 import androidx.compose.material.Text
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.CloudUpload
+import androidx.compose.material.icons.outlined.Warning
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.MutableState
@@ -38,9 +39,11 @@ import com.google.accompanist.insets.statusBarsHeight
 import de.schnettler.scrobbler.compose.navigation.UIAction
 import de.schnettler.scrobbler.compose.navigation.UIAction.ListingSelected
 import de.schnettler.scrobbler.compose.navigation.UIError
+import de.schnettler.scrobbler.compose.theme.AppColor
 import de.schnettler.scrobbler.compose.widget.CustomDivider
 import de.schnettler.scrobbler.compose.widget.FullScreenError
 import de.schnettler.scrobbler.compose.widget.LoadingContent
+import de.schnettler.scrobbler.compose.widget.PlainListIconBackground
 import de.schnettler.scrobbler.history.R
 import de.schnettler.scrobbler.history.ktx.notificationListenerEnabled
 import de.schnettler.scrobbler.history.model.HistoryError
@@ -258,7 +261,21 @@ fun HistoryTrackList(
             item {
                 ListItem(
                     text = {
-                        Text(text = "Ignored $ignoredCount")
+                        Text(text = "Scrobbles rejected")
+                    },
+                    secondaryText = {
+                        Text(text = "$ignoredCount scrobbles were rejected by last.fm")
+                    },
+                    icon = {
+                        PlainListIconBackground(
+                            color = AppColor.Error.copy(0.4f)
+                        ) {
+                            Icon(
+                                imageVector = Icons.Outlined.Warning,
+                                contentDescription = null,
+                                tint = AppColor.Error,
+                                modifier = Modifier.size(16.dp))
+                        }
                     }
                 )
             }

--- a/features/history/src/main/java/de/schnettler/scrobbler/history/ui/HistoryScreen.kt
+++ b/features/history/src/main/java/de/schnettler/scrobbler/history/ui/HistoryScreen.kt
@@ -15,11 +15,9 @@ import androidx.compose.material.CircularProgressIndicator
 import androidx.compose.material.ExperimentalMaterialApi
 import androidx.compose.material.ExtendedFloatingActionButton
 import androidx.compose.material.Icon
-import androidx.compose.material.ListItem
 import androidx.compose.material.Text
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.CloudUpload
-import androidx.compose.material.icons.outlined.Warning
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.MutableState
@@ -39,11 +37,9 @@ import com.google.accompanist.insets.statusBarsHeight
 import de.schnettler.scrobbler.compose.navigation.UIAction
 import de.schnettler.scrobbler.compose.navigation.UIAction.ListingSelected
 import de.schnettler.scrobbler.compose.navigation.UIError
-import de.schnettler.scrobbler.compose.theme.AppColor
 import de.schnettler.scrobbler.compose.widget.CustomDivider
 import de.schnettler.scrobbler.compose.widget.FullScreenError
 import de.schnettler.scrobbler.compose.widget.LoadingContent
-import de.schnettler.scrobbler.compose.widget.PlainListIconBackground
 import de.schnettler.scrobbler.history.R
 import de.schnettler.scrobbler.history.ktx.notificationListenerEnabled
 import de.schnettler.scrobbler.history.model.HistoryError
@@ -58,6 +54,7 @@ import de.schnettler.scrobbler.history.ui.dialog.SubmissionResultDetailsDialog
 import de.schnettler.scrobbler.history.ui.dialog.TrackEditDialog
 import de.schnettler.scrobbler.history.ui.widget.ErrorItem
 import de.schnettler.scrobbler.history.ui.widget.NowPlayingItem
+import de.schnettler.scrobbler.history.ui.widget.RejectedScrobblesItem
 import de.schnettler.scrobbler.history.ui.widget.ScrobbleItem
 import de.schnettler.scrobbler.model.Scrobble
 
@@ -258,27 +255,7 @@ fun HistoryTrackList(
         }
 
         if (ignoredCount > 0) {
-            item {
-                ListItem(
-                    text = {
-                        Text(text = "Scrobbles rejected")
-                    },
-                    secondaryText = {
-                        Text(text = "$ignoredCount scrobbles were rejected by last.fm")
-                    },
-                    icon = {
-                        PlainListIconBackground(
-                            color = AppColor.Error.copy(0.4f)
-                        ) {
-                            Icon(
-                                imageVector = Icons.Outlined.Warning,
-                                contentDescription = null,
-                                tint = AppColor.Error,
-                                modifier = Modifier.size(16.dp))
-                        }
-                    }
-                )
-            }
+            item { RejectedScrobblesItem(ignoredCount) }
         }
 
         items(tracks) { track ->

--- a/features/history/src/main/java/de/schnettler/scrobbler/history/ui/HistoryScreen.kt
+++ b/features/history/src/main/java/de/schnettler/scrobbler/history/ui/HistoryScreen.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxScope
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -11,8 +12,10 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.Card
 import androidx.compose.material.CircularProgressIndicator
+import androidx.compose.material.ExperimentalMaterialApi
 import androidx.compose.material.ExtendedFloatingActionButton
 import androidx.compose.material.Icon
+import androidx.compose.material.ListItem
 import androidx.compose.material.Text
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.CloudUpload
@@ -88,7 +91,8 @@ fun Content(
     }
 
     val recentTracksState by localViewModel.state.collectAsState()
-    val cachedNumber by localViewModel.cachedScrobblesCOunt.collectAsState(initial = 0)
+    val cachedNumber by localViewModel.cachedScrobblesCount.collectAsState(initial = 0)
+    val ignoredNumber by localViewModel.ignoredScrobblesCount.collectAsState(initial = 0)
     var showEditDialog by remember { mutableStateOf(false) }
     var showConfirmDialog by remember { mutableStateOf(false) }
     val selectedTrack: MutableState<Scrobble?> = remember { mutableStateOf(null) }
@@ -119,6 +123,7 @@ fun Content(
             recentTracksState.currentData?.let { list ->
                 HistoryTrackList(
                     tracks = list,
+                    ignoredCount = ignoredNumber,
                     onActionClicked = { track, actionType ->
                         selectedTrack.value = track
                         when (actionType) {
@@ -218,9 +223,11 @@ private fun getErrors(context: Context, loggedIn: Boolean) = listOfNotNull(
     if (!loggedIn) HistoryError.LoggedOut else null
 )
 
+@OptIn(ExperimentalMaterialApi::class)
 @Composable
 fun HistoryTrackList(
     tracks: List<Scrobble>,
+    ignoredCount: Int,
     onActionClicked: (Scrobble, ScrobbleAction) -> Unit,
     onNowPlayingSelected: (Scrobble) -> Unit,
     onErrorClicked: (HistoryError) -> Unit,
@@ -228,7 +235,7 @@ fun HistoryTrackList(
 ) {
     LazyColumn {
         item {
-            androidx.compose.foundation.layout.Spacer(modifier = Modifier.statusBarsHeight())
+            Spacer(modifier = Modifier.statusBarsHeight())
         }
 
         item {
@@ -244,6 +251,16 @@ fun HistoryTrackList(
                         }
                     }
                 }
+            }
+        }
+
+        if (ignoredCount > 0) {
+            item {
+                ListItem(
+                    text = {
+                        Text(text = "Ignored $ignoredCount")
+                    }
+                )
             }
         }
 

--- a/features/history/src/main/java/de/schnettler/scrobbler/history/ui/HistoryScreen.kt
+++ b/features/history/src/main/java/de/schnettler/scrobbler/history/ui/HistoryScreen.kt
@@ -1,6 +1,10 @@
 package de.schnettler.scrobbler.history.ui
 
 import android.content.Context
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.ExperimentalAnimationApi
+import androidx.compose.animation.expandVertically
+import androidx.compose.animation.shrinkVertically
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxScope
 import androidx.compose.foundation.layout.Column
@@ -223,7 +227,7 @@ private fun getErrors(context: Context, loggedIn: Boolean) = listOfNotNull(
     if (!loggedIn) HistoryError.LoggedOut else null
 )
 
-@OptIn(ExperimentalMaterialApi::class)
+@OptIn(ExperimentalMaterialApi::class, ExperimentalAnimationApi::class)
 @Composable
 fun HistoryTrackList(
     tracks: List<Scrobble>,
@@ -254,8 +258,14 @@ fun HistoryTrackList(
             }
         }
 
-        if (ignoredCount > 0) {
-            item { RejectedScrobblesItem(ignoredCount) }
+        item {
+            AnimatedVisibility(
+                visible = ignoredCount > 0,
+                enter = expandVertically(),
+                exit = shrinkVertically(shrinkTowards = Alignment.Top)
+            ) {
+                RejectedScrobblesItem(ignoredCount)
+            }
         }
 
         items(tracks) { track ->

--- a/features/history/src/main/java/de/schnettler/scrobbler/history/ui/LocalViewModel.kt
+++ b/features/history/src/main/java/de/schnettler/scrobbler/history/ui/LocalViewModel.kt
@@ -3,7 +3,6 @@ package de.schnettler.scrobbler.history.ui
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
-import de.schnettler.lastfm.models.LastFmResponse
 import de.schnettler.scrobbler.core.ui.viewmodel.RefreshableStateViewModel
 import de.schnettler.scrobbler.history.domain.LocalRepository
 import de.schnettler.scrobbler.history.domain.RejectionCodeToReasonMapper
@@ -75,22 +74,19 @@ class LocalViewModel @Inject constructor(
     }
 
     fun submitScrobble(track: Scrobble) {
-        viewModelScope.launch(Dispatchers.IO) {
-            val response = submissionRepo.submitScrobble(track)
-            if (response is LastFmResponse.SUCCESS) {
-                submissionRepo.markScrobblesAsSubmitted(track)
-            }
+        viewModelScope.launch {
+            submissionRepo.submitScrobble(track)
         }
     }
 
     fun deleteScrobble(scrobble: Scrobble) {
-        viewModelScope.launch(Dispatchers.IO) {
+        viewModelScope.launch {
             submissionRepo.deleteScrobble(scrobble)
         }
     }
 
     fun editCachedScrobble(scrobble: Scrobble) {
-        viewModelScope.launch(Dispatchers.IO) {
+        viewModelScope.launch {
             submissionRepo.submitScrobbleEdit(scrobble)
         }
     }

--- a/features/history/src/main/java/de/schnettler/scrobbler/history/ui/LocalViewModel.kt
+++ b/features/history/src/main/java/de/schnettler/scrobbler/history/ui/LocalViewModel.kt
@@ -29,19 +29,23 @@ class LocalViewModel @Inject constructor(
 
     val events = MutableLiveData<Event<SubmissionEvent>>()
 
-    val cachedScrobblesCOunt by lazy {
+    val cachedScrobblesCount by lazy {
         repo.getNumberOfCachedScrobbles()
+    }
+
+    val ignoredScrobblesCount by lazy {
+        repo.getNumberOfIgnoredScrobbles()
     }
 
     fun scheduleScrobbleSubmission() {
         isSubmitting.value = true
         viewModelScope.launch(Dispatchers.IO) {
-            val result = submissionRepo.submitCachedScrobbles()
+            val results = submissionRepo.submitCachedScrobbles()
 
-            val errorMessage = result.errors.firstOrNull()?.description ?: result.exceptions.firstOrNull()?.message
+            val errorMessage = results.errors.firstOrNull()?.message
             val mappedResult = SubmissionResult(
-                accepted = result.accepted.map { it.timestamp },
-                ignored = result.ignored.associateBy({ it.timestamp }, { it.ignoredMessage.code }),
+                accepted = results.accepted.map { it.timestamp },
+                ignored = results.ignored.associateBy({ it.timestamp }, { it.ignoredMessage.code }),
                 error = errorMessage
             )
             events.postValue(Event(SubmissionEvent.Success(mappedResult)))

--- a/features/history/src/main/java/de/schnettler/scrobbler/history/ui/widget/RejectedScrobblesItem.kt
+++ b/features/history/src/main/java/de/schnettler/scrobbler/history/ui/widget/RejectedScrobblesItem.kt
@@ -1,0 +1,45 @@
+package de.schnettler.scrobbler.history.ui.widget
+
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.Card
+import androidx.compose.material.ExperimentalMaterialApi
+import androidx.compose.material.Icon
+import androidx.compose.material.ListItem
+import androidx.compose.material.Text
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.Warning
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import de.schnettler.scrobbler.compose.theme.AppColor
+import de.schnettler.scrobbler.compose.widget.PlainListIconBackground
+import de.schnettler.scrobbler.history.R
+
+@ExperimentalMaterialApi
+@Composable
+internal fun RejectedScrobblesItem(ignoredCount: Int) {
+    Card(modifier = Modifier.padding(16.dp)) {
+        ListItem(
+            text = {
+                Text(text = stringResource(id = R.string.scrobbles_rejected_title))
+            },
+            secondaryText = {
+                Text(text = "$ignoredCount " + stringResource(id = R.string.scrobbles_rejected_description))
+            },
+            icon = {
+                PlainListIconBackground(
+                    color = AppColor.Error.copy(0.4f)
+                ) {
+                    Icon(
+                        imageVector = Icons.Outlined.Warning,
+                        contentDescription = null,
+                        tint = AppColor.Error,
+                        modifier = Modifier.size(16.dp)
+                    )
+                }
+            }
+        )
+    }
+}

--- a/features/history/src/main/java/de/schnettler/scrobbler/history/ui/widget/ScrobbleItem.kt
+++ b/features/history/src/main/java/de/schnettler/scrobbler/history/ui/widget/ScrobbleItem.kt
@@ -147,7 +147,7 @@ private fun InformationItem(category: String, value: String) {
 @Composable
 fun QuickActions(status: ScrobbleStatus, onActionClicked: (ScrobbleAction) -> Unit) {
     val actions = mutableListOf<ScrobbleAction>()
-    when(status) {
+    when (status) {
         ScrobbleStatus.LOCAL -> {
             actions.addAll(listOf(ScrobbleAction.EDIT, ScrobbleAction.DELETE, ScrobbleAction.SUBMIT))
         }

--- a/features/history/src/main/java/de/schnettler/scrobbler/history/ui/widget/ScrobbleItem.kt
+++ b/features/history/src/main/java/de/schnettler/scrobbler/history/ui/widget/ScrobbleItem.kt
@@ -1,9 +1,11 @@
 package de.schnettler.scrobbler.history.ui.widget
 
+import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -11,13 +13,11 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.ExperimentalMaterialApi
 import androidx.compose.material.Icon
 import androidx.compose.material.IconButton
 import androidx.compose.material.ListItem
 import androidx.compose.material.MaterialTheme
-import androidx.compose.material.Surface
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -26,11 +26,13 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import de.schnettler.scrobbler.compose.theme.AppColor
 import de.schnettler.scrobbler.compose.widget.CustomDivider
 import de.schnettler.scrobbler.compose.widget.NameListIcon
 import de.schnettler.scrobbler.core.ktx.asMinSec
@@ -39,6 +41,7 @@ import de.schnettler.scrobbler.core.ktx.packageNameToAppName
 import de.schnettler.scrobbler.history.R
 import de.schnettler.scrobbler.history.model.ScrobbleAction
 import de.schnettler.scrobbler.model.Scrobble
+import de.schnettler.scrobbler.model.ScrobbleStatus
 import kotlin.time.Duration
 import kotlin.time.ExperimentalTime
 
@@ -66,7 +69,7 @@ fun ScrobbleItem(track: Scrobble, onActionClicked: (ScrobbleAction) -> Unit) {
                     )
                     else Spacer(modifier = Modifier.height(16.dp))
                     CustomDivider()
-                    QuickActions(track.isCached(), onActionClicked)
+                    QuickActions(track.status, onActionClicked)
                 }
             }
         },
@@ -79,20 +82,35 @@ fun ScrobbleItem(track: Scrobble, onActionClicked: (ScrobbleAction) -> Unit) {
             track.timestampToRelativeTime()?.let {
                 Column(verticalArrangement = Arrangement.Center) {
                     Text(text = it)
-                    if (track.isCached()) {
-                        Surface(
-                            color = MaterialTheme.colors.secondary,
-                            shape = CircleShape,
-                            modifier = Modifier.padding(top = 8.dp, end = 16.dp).size(8.dp).align(
-                                Alignment.End
-                            )
-                        ) { }
+
+                    when (track.status) {
+                        ScrobbleStatus.LOCAL -> {
+                            StatusIndicator(color = MaterialTheme.colors.secondary)
+                        }
+                        ScrobbleStatus.SUBMISSION_FAILED -> {
+                            StatusIndicator(color = AppColor.Error)
+                        }
+                        else -> Unit
                     }
                 }
             }
         }
     )
     CustomDivider()
+}
+
+@Composable
+private fun ColumnScope.StatusIndicator(
+    color: Color,
+) {
+    Canvas(modifier = Modifier
+        .padding(top = 8.dp, end = 16.dp)
+        .size(8.dp)
+        .align(
+            Alignment.End
+        ), onDraw = {
+        drawCircle(color = color)
+    })
 }
 
 @ExperimentalTime
@@ -127,9 +145,17 @@ private fun InformationItem(category: String, value: String) {
 }
 
 @Composable
-fun QuickActions(isCached: Boolean, onActionClicked: (ScrobbleAction) -> Unit) {
+fun QuickActions(status: ScrobbleStatus, onActionClicked: (ScrobbleAction) -> Unit) {
     val actions = mutableListOf<ScrobbleAction>()
-    if (isCached) { actions.addAll(listOf(ScrobbleAction.EDIT, ScrobbleAction.DELETE, ScrobbleAction.SUBMIT)) }
+    when(status) {
+        ScrobbleStatus.LOCAL -> {
+            actions.addAll(listOf(ScrobbleAction.EDIT, ScrobbleAction.DELETE, ScrobbleAction.SUBMIT))
+        }
+        ScrobbleStatus.SUBMISSION_FAILED -> {
+            actions.addAll(listOf(ScrobbleAction.EDIT, ScrobbleAction.DELETE))
+        }
+        else -> Unit
+    }
     actions.add(ScrobbleAction.OPEN)
     QuickActionsRow(items = actions, onSelect = onActionClicked)
 }

--- a/features/history/src/main/res/values-de/strings.xml
+++ b/features/history/src/main/res/values-de/strings.xml
@@ -35,4 +35,8 @@
     <string name="scrobble_source">Quelle</string>
     <string name="scrobble_runtime">Laufzeit</string>
     <string name="scrobble_timestamp">Zeitstempel</string>
+
+    <!-- Rejected -->
+    <string name="scrobbles_rejected_title">Scrobbles abgelehnt</string>
+    <string name="scrobbles_rejected_description">Scrobbles wurden von last.fm abgelehnt</string>
 </resources>

--- a/features/history/src/main/res/values-de/strings.xml
+++ b/features/history/src/main/res/values-de/strings.xml
@@ -38,5 +38,5 @@
 
     <!-- Rejected -->
     <string name="scrobbles_rejected_title">Scrobbles abgelehnt</string>
-    <string name="scrobbles_rejected_description">Scrobbles wurden von last.fm abgelehnt</string>
+    <string name="scrobbles_rejected_description">Scrobbles von last.fm abgelehnt</string>
 </resources>

--- a/features/history/src/main/res/values/strings.xml
+++ b/features/history/src/main/res/values/strings.xml
@@ -37,4 +37,8 @@
     <string name="scrobble_source">Source</string>
     <string name="scrobble_runtime">Runtime</string>
     <string name="scrobble_timestamp">Timestamp</string>
+
+    <!-- Rejected -->
+    <string name="scrobbles_rejected_title">Scrobbles rejected</string>
+    <string name="scrobbles_rejected_description">scrobbles were rejected by last.fm</string>
 </resources>

--- a/libraries/model/src/main/java/de/schnettler/scrobbler/model/Scrobble.kt
+++ b/libraries/model/src/main/java/de/schnettler/scrobbler/model/Scrobble.kt
@@ -5,7 +5,7 @@ import android.text.format.DateUtils
 import androidx.room.Entity
 import androidx.room.Ignore
 import androidx.room.PrimaryKey
-import java.util.Locale
+import java.util.*
 import kotlin.math.roundToInt
 import kotlin.time.Duration
 import kotlin.time.DurationUnit
@@ -45,6 +45,7 @@ data class Scrobble(
     fun isPlaying() = status == ScrobbleStatus.PLAYING
     fun isLocal() = isCached() || status == ScrobbleStatus.SCROBBLED
     fun isCached() = status == ScrobbleStatus.LOCAL
+    fun isEditable() = isCached() || status == ScrobbleStatus.SUBMISSION_FAILED
     fun timestampToRelativeTime() =
         if (timestamp > 0) {
             DateUtils.getRelativeTimeSpanString(

--- a/libraries/model/src/main/java/de/schnettler/scrobbler/model/Scrobble.kt
+++ b/libraries/model/src/main/java/de/schnettler/scrobbler/model/Scrobble.kt
@@ -107,6 +107,7 @@ enum class ScrobbleStatus {
     PLAYING,
     PAUSED,
     SCROBBLED,
+    SUBMISSION_FAILED,
     VOLATILE,
     EXTERNAL
 }

--- a/libraries/model/src/main/java/de/schnettler/scrobbler/model/Scrobble.kt
+++ b/libraries/model/src/main/java/de/schnettler/scrobbler/model/Scrobble.kt
@@ -5,7 +5,7 @@ import android.text.format.DateUtils
 import androidx.room.Entity
 import androidx.room.Ignore
 import androidx.room.PrimaryKey
-import java.util.*
+import java.util.Locale
 import kotlin.math.roundToInt
 import kotlin.time.Duration
 import kotlin.time.DurationUnit
@@ -28,8 +28,10 @@ data class Scrobble(
     var status: ScrobbleStatus = ScrobbleStatus.VOLATILE,
     var trackingStart: Long = timestamp
 ) {
-    @Ignore val id: String = name.toLowerCase(Locale.US)
-    @Ignore val url: String = "https://www.last.fm/music/$artist/_/$name"
+    @Ignore
+    val id: String = name.toLowerCase(Locale.US)
+    @Ignore
+    val url: String = "https://www.last.fm/music/$artist/_/$name"
 
     val playDuration: Duration
         get() = amountPlayed.toDuration(DurationUnit.MILLISECONDS)
@@ -45,7 +47,6 @@ data class Scrobble(
     fun isPlaying() = status == ScrobbleStatus.PLAYING
     fun isLocal() = isCached() || status == ScrobbleStatus.SCROBBLED
     fun isCached() = status == ScrobbleStatus.LOCAL
-    fun isEditable() = isCached() || status == ScrobbleStatus.SUBMISSION_FAILED
     fun timestampToRelativeTime() =
         if (timestamp > 0) {
             DateUtils.getRelativeTimeSpanString(
@@ -53,6 +54,7 @@ data class Scrobble(
                     .MINUTE_IN_MILLIS, DateUtils.FORMAT_ABBREV_ALL
             ).toString()
         } else null
+
     fun isTheSameAs(track: Scrobble?) = name == track?.name && artist == track.artist
     private fun canBeScrobbled() = duration > 30000
 

--- a/libraries/network/lastfm/src/main/java/de/schnettler/lastfm/models/Error.kt
+++ b/libraries/network/lastfm/src/main/java/de/schnettler/lastfm/models/Error.kt
@@ -85,4 +85,6 @@ enum class Errors(private val num: Long, val title: String, val description: Str
     );
 
     override fun toString(): String = "[$num] $name: $title - $description"
+
+    fun isRecoverable() = this == OFFLINE || this == UNAVAILABLE
 }

--- a/libraries/submission/build.gradle.kts
+++ b/libraries/submission/build.gradle.kts
@@ -23,6 +23,7 @@ dependencies {
     implementation(project(":libraries:network:common"))
     implementation(project(":libraries:network:lastfm"))
     implementation(project(":libraries:persistence"))
+    implementation(project(":libraries:core"))
 
     // Network & Serialization
     implementation(Square.Retrofit2.retrofit)
@@ -40,7 +41,6 @@ dependencies {
 
     // Dagger
     implementation(Google.dagger.hilt.android)
-    implementation(project(mapOf("path" to ":libraries:core")))
     kapt(Google.dagger.hilt.compiler)
     kapt(AndroidX.hilt.compiler)
 

--- a/libraries/submission/build.gradle.kts
+++ b/libraries/submission/build.gradle.kts
@@ -40,6 +40,7 @@ dependencies {
 
     // Dagger
     implementation(Google.dagger.hilt.android)
+    implementation(project(mapOf("path" to ":libraries:core")))
     kapt(Google.dagger.hilt.compiler)
     kapt(AndroidX.hilt.compiler)
 

--- a/libraries/submission/src/main/java/de/schnettler/scrobbler/submission/api/SubmissionApi.kt
+++ b/libraries/submission/src/main/java/de/schnettler/scrobbler/submission/api/SubmissionApi.kt
@@ -3,7 +3,7 @@ package de.schnettler.scrobbler.submission.api
 import com.serjltt.moshi.adapters.Wrapped
 import de.schnettler.scrobbler.network.common.annotation.tag.SessionAuthentication
 import de.schnettler.scrobbler.network.common.annotation.tag.SignatureAuthentication
-import de.schnettler.scrobbler.submission.model.MutlipleScrobblesResponse
+import de.schnettler.scrobbler.submission.model.MultiScrobbleResponse
 import de.schnettler.scrobbler.submission.model.NowPlayingResponse
 import de.schnettler.scrobbler.submission.model.SingleScrobbleResponse
 import retrofit2.Response
@@ -37,5 +37,5 @@ interface SubmissionApi {
     @Wrapped(path = ["scrobbles"])
     suspend fun submitMultipleScrobbles(
         @QueryMap body: Map<String, String>
-    ): Response<MutlipleScrobblesResponse>
+    ): Response<MultiScrobbleResponse>
 }

--- a/libraries/submission/src/main/java/de/schnettler/scrobbler/submission/db/SubmissionFailureDao.kt
+++ b/libraries/submission/src/main/java/de/schnettler/scrobbler/submission/db/SubmissionFailureDao.kt
@@ -1,0 +1,10 @@
+package de.schnettler.scrobbler.submission.db
+
+import androidx.room.Dao
+import de.schnettler.scrobbler.persistence.dao.BaseDao
+import de.schnettler.scrobbler.submission.model.SubmissionFailureEntity
+
+@Dao
+abstract class SubmissionFailureDao : BaseDao<SubmissionFailureEntity> {
+
+}

--- a/libraries/submission/src/main/java/de/schnettler/scrobbler/submission/db/SubmissionFailureDao.kt
+++ b/libraries/submission/src/main/java/de/schnettler/scrobbler/submission/db/SubmissionFailureDao.kt
@@ -1,10 +1,17 @@
 package de.schnettler.scrobbler.submission.db
 
 import androidx.room.Dao
+import androidx.room.Query
 import de.schnettler.scrobbler.persistence.dao.BaseDao
 import de.schnettler.scrobbler.submission.model.SubmissionFailureEntity
+import kotlinx.coroutines.flow.Flow
 
 @Dao
 abstract class SubmissionFailureDao : BaseDao<SubmissionFailureEntity> {
 
+    @Query("SELECT COUNT(timestamp) FROM submission_failure")
+    abstract fun getNumberOfIgnoredScrobbles(): Flow<Int>
+
+    @Query("DELETE FROM submission_failure WHERE timestamp in (:timestamps)")
+    abstract fun deleteEntries(timestamps: List<Long>)
 }

--- a/libraries/submission/src/main/java/de/schnettler/scrobbler/submission/domain/SubmissionDao.kt
+++ b/libraries/submission/src/main/java/de/schnettler/scrobbler/submission/domain/SubmissionDao.kt
@@ -15,5 +15,5 @@ abstract class SubmissionDao : BaseDao<Scrobble> {
     abstract suspend fun updateTrackData(timestamp: Long, track: String, artist: String, album: String)
 
     @Query("UPDATE localTracks SET status = :status WHERE timestamp in (:timestamps)")
-    abstract suspend fun updateScrobbleStatus(timestamps: List<Long>, status: ScrobbleStatus = ScrobbleStatus.SCROBBLED)
+    abstract suspend fun updateScrobbleStatus(timestamps: List<Long>, status: ScrobbleStatus)
 }

--- a/libraries/submission/src/main/java/de/schnettler/scrobbler/submission/domain/SubmissionDao.kt
+++ b/libraries/submission/src/main/java/de/schnettler/scrobbler/submission/domain/SubmissionDao.kt
@@ -2,6 +2,7 @@ package de.schnettler.scrobbler.submission.domain
 
 import androidx.room.Dao
 import androidx.room.Query
+import androidx.room.Transaction
 import de.schnettler.scrobbler.model.Scrobble
 import de.schnettler.scrobbler.model.ScrobbleStatus
 import de.schnettler.scrobbler.persistence.dao.BaseDao
@@ -16,4 +17,10 @@ abstract class SubmissionDao : BaseDao<Scrobble> {
 
     @Query("UPDATE localTracks SET status = :status WHERE timestamp in (:timestamps)")
     abstract suspend fun updateScrobbleStatus(timestamps: List<Long>, status: ScrobbleStatus)
+
+    @Transaction
+    open suspend fun updateScrobbleData(scrobble: Scrobble) {
+        updateTrackData(scrobble.timestamp, scrobble.name, scrobble.artist, scrobble.album)
+        updateScrobbleStatus(listOf(scrobble.timestamp), ScrobbleStatus.LOCAL)
+    }
 }

--- a/libraries/submission/src/main/java/de/schnettler/scrobbler/submission/domain/SubmissionRemoteDataSource.kt
+++ b/libraries/submission/src/main/java/de/schnettler/scrobbler/submission/domain/SubmissionRemoteDataSource.kt
@@ -1,0 +1,48 @@
+package de.schnettler.scrobbler.submission.domain
+
+import de.schnettler.lastfm.map.ResponseToLastFmResponseMapper
+import de.schnettler.lastfm.models.LastFmResponse
+import de.schnettler.scrobbler.model.Scrobble
+import de.schnettler.scrobbler.submission.api.SubmissionApi
+import de.schnettler.scrobbler.submission.model.MultiScrobbleResponse
+import de.schnettler.scrobbler.submission.model.SingleScrobbleResponse
+import de.schnettler.scrobbler.submission.safePost
+import javax.inject.Inject
+
+class SubmissionRemoteDataSource @Inject constructor(
+    private val submissionApi: SubmissionApi,
+) {
+    suspend fun submitScrobbleChunk(tracks: List<Scrobble>): LastFmResponse<MultiScrobbleResponse> {
+        val parameters = tracks.mapIndexed { index: Int, scrobble: Scrobble ->
+            mapOf(
+                "artist[$index]" to scrobble.artist,
+                "track[$index]" to scrobble.name,
+                "album[$index]" to scrobble.album,
+                "duration[$index]" to scrobble.durationUnix(),
+                "timestamp[$index]" to scrobble.timeStampString(),
+            )
+        }.reduce { acc, map -> acc + map }
+
+        return safePost {
+            ResponseToLastFmResponseMapper.map(
+                submissionApi.submitMultipleScrobbles(
+                    parameters
+                )
+            )
+        }
+    }
+
+    suspend fun submitScrobble(track: Scrobble): LastFmResponse<SingleScrobbleResponse> {
+        return safePost {
+            ResponseToLastFmResponseMapper.map(
+                submissionApi.submitScrobble(
+                    artist = track.artist,
+                    track = track.name,
+                    timestamp = track.timeStampString(),
+                    album = track.album,
+                    duration = track.durationUnix(),
+                )
+            )
+        }
+    }
+}

--- a/libraries/submission/src/main/java/de/schnettler/scrobbler/submission/map/MultiSubmissionResponseMapper.kt
+++ b/libraries/submission/src/main/java/de/schnettler/scrobbler/submission/map/MultiSubmissionResponseMapper.kt
@@ -6,7 +6,8 @@ import de.schnettler.scrobbler.submission.model.MultiScrobbleResponse
 import de.schnettler.scrobbler.submission.model.SubmissionResult
 import javax.inject.Inject
 
-class MultiSubmissionResponseMapper @Inject constructor() : Mapper<LastFmResponse<MultiScrobbleResponse>, SubmissionResult> {
+class MultiSubmissionResponseMapper @Inject constructor() :
+    Mapper<LastFmResponse<MultiScrobbleResponse>, SubmissionResult> {
     override suspend fun map(from: LastFmResponse<MultiScrobbleResponse>): SubmissionResult {
         return when (from) {
             is LastFmResponse.ERROR -> SubmissionResult.Error(

--- a/libraries/submission/src/main/java/de/schnettler/scrobbler/submission/map/MultiSubmissionResponseMapper.kt
+++ b/libraries/submission/src/main/java/de/schnettler/scrobbler/submission/map/MultiSubmissionResponseMapper.kt
@@ -1,0 +1,25 @@
+package de.schnettler.scrobbler.submission.map
+
+import de.schnettler.lastfm.models.LastFmResponse
+import de.schnettler.scrobbler.core.map.Mapper
+import de.schnettler.scrobbler.submission.model.MultiScrobbleResponse
+import de.schnettler.scrobbler.submission.model.SubmissionResult
+import javax.inject.Inject
+
+class MultiSubmissionResponseMapper @Inject constructor() : Mapper<LastFmResponse<MultiScrobbleResponse>, SubmissionResult> {
+    override suspend fun map(from: LastFmResponse<MultiScrobbleResponse>): SubmissionResult {
+        return when (from) {
+            is LastFmResponse.ERROR -> SubmissionResult.Error(
+                message = from.error?.description.orEmpty(),
+                recoverable = from.error?.isRecoverable() == true
+            )
+            is LastFmResponse.EXCEPTION -> SubmissionResult.Error(from.exception.localizedMessage.orEmpty())
+            is LastFmResponse.SUCCESS -> {
+                from.data?.let { responseData ->
+                    val (accepted, ignored) = responseData.scrobble.partition { it.accepted() }
+                    SubmissionResult.Success(accepted = accepted, ignored = ignored)
+                } ?: SubmissionResult.Success(emptyList(), emptyList())
+            }
+        }
+    }
+}

--- a/libraries/submission/src/main/java/de/schnettler/scrobbler/submission/map/ScrobbleResponseToSubmissionFailureEntityMapper.kt
+++ b/libraries/submission/src/main/java/de/schnettler/scrobbler/submission/map/ScrobbleResponseToSubmissionFailureEntityMapper.kt
@@ -1,0 +1,16 @@
+package de.schnettler.scrobbler.submission.map
+
+import de.schnettler.scrobbler.core.map.Mapper
+import de.schnettler.scrobbler.submission.model.ScrobbleResponse
+import de.schnettler.scrobbler.submission.model.SubmissionFailureEntity
+import javax.inject.Inject
+
+class ScrobbleResponseToSubmissionFailureEntityMapper @Inject constructor() : Mapper<ScrobbleResponse, SubmissionFailureEntity> {
+    override suspend fun map(from: ScrobbleResponse): SubmissionFailureEntity {
+        return SubmissionFailureEntity(
+            timestamp = from.timestamp,
+            failureCode = from.ignoredMessage.code,
+            failureReason = from.ignoredMessage.reason
+        )
+    }
+}

--- a/libraries/submission/src/main/java/de/schnettler/scrobbler/submission/map/ScrobbleResponseToSubmissionFailureEntityMapper.kt
+++ b/libraries/submission/src/main/java/de/schnettler/scrobbler/submission/map/ScrobbleResponseToSubmissionFailureEntityMapper.kt
@@ -5,7 +5,8 @@ import de.schnettler.scrobbler.submission.model.ScrobbleResponse
 import de.schnettler.scrobbler.submission.model.SubmissionFailureEntity
 import javax.inject.Inject
 
-class ScrobbleResponseToSubmissionFailureEntityMapper @Inject constructor() : Mapper<ScrobbleResponse, SubmissionFailureEntity> {
+class ScrobbleResponseToSubmissionFailureEntityMapper @Inject constructor() :
+    Mapper<ScrobbleResponse, SubmissionFailureEntity> {
     override suspend fun map(from: ScrobbleResponse): SubmissionFailureEntity {
         return SubmissionFailureEntity(
             timestamp = from.timestamp,

--- a/libraries/submission/src/main/java/de/schnettler/scrobbler/submission/map/SingleSubmissionResponseMapper.kt
+++ b/libraries/submission/src/main/java/de/schnettler/scrobbler/submission/map/SingleSubmissionResponseMapper.kt
@@ -7,7 +7,8 @@ import de.schnettler.scrobbler.submission.model.SingleScrobbleResponse
 import de.schnettler.scrobbler.submission.model.SubmissionResult
 import javax.inject.Inject
 
-class SingleSubmissionResponseMapper @Inject constructor() : Mapper<LastFmResponse<SingleScrobbleResponse>, SubmissionResult> {
+class SingleSubmissionResponseMapper @Inject constructor() :
+    Mapper<LastFmResponse<SingleScrobbleResponse>, SubmissionResult> {
     override suspend fun map(from: LastFmResponse<SingleScrobbleResponse>): SubmissionResult {
         return when (from) {
             is LastFmResponse.ERROR -> SubmissionResult.Error(

--- a/libraries/submission/src/main/java/de/schnettler/scrobbler/submission/map/SingleSubmissionResponseMapper.kt
+++ b/libraries/submission/src/main/java/de/schnettler/scrobbler/submission/map/SingleSubmissionResponseMapper.kt
@@ -1,0 +1,34 @@
+package de.schnettler.scrobbler.submission.map
+
+import de.schnettler.lastfm.models.LastFmResponse
+import de.schnettler.scrobbler.core.map.Mapper
+import de.schnettler.scrobbler.submission.model.ScrobbleResponse
+import de.schnettler.scrobbler.submission.model.SingleScrobbleResponse
+import de.schnettler.scrobbler.submission.model.SubmissionResult
+import javax.inject.Inject
+
+class SingleSubmissionResponseMapper @Inject constructor() : Mapper<LastFmResponse<SingleScrobbleResponse>, SubmissionResult> {
+    override suspend fun map(from: LastFmResponse<SingleScrobbleResponse>): SubmissionResult {
+        return when (from) {
+            is LastFmResponse.ERROR -> SubmissionResult.Error(
+                message = from.error?.description.orEmpty(),
+                recoverable = from.error?.isRecoverable() == true
+            )
+            is LastFmResponse.EXCEPTION -> SubmissionResult.Error(from.exception.localizedMessage.orEmpty())
+            is LastFmResponse.SUCCESS -> {
+                from.data?.scrobble?.let { response ->
+                    val accepted = mutableListOf<ScrobbleResponse>()
+                    val ignored = mutableListOf<ScrobbleResponse>()
+
+                    if (response.accepted()) {
+                        accepted.add(response)
+                    } else {
+                        ignored.add(response)
+                    }
+
+                    SubmissionResult.Success(accepted = accepted, ignored = ignored)
+                } ?: SubmissionResult.Success(emptyList(), emptyList())
+            }
+        }
+    }
+}

--- a/libraries/submission/src/main/java/de/schnettler/scrobbler/submission/model/ScrobbleResponse.kt
+++ b/libraries/submission/src/main/java/de/schnettler/scrobbler/submission/model/ScrobbleResponse.kt
@@ -28,5 +28,5 @@ data class ScrobbleResponse(
     val track: CorrectionResponse,
     val ignoredMessage: IgnoredResponse
 ) {
-    fun accepted() = ignoredMessage.code  == 0L
+    fun accepted() = ignoredMessage.code == 0L
 }

--- a/libraries/submission/src/main/java/de/schnettler/scrobbler/submission/model/ScrobbleResponse.kt
+++ b/libraries/submission/src/main/java/de/schnettler/scrobbler/submission/model/ScrobbleResponse.kt
@@ -8,7 +8,7 @@ interface GeneralScrobbleResponse {
 }
 
 @JsonClass(generateAdapter = true)
-data class MutlipleScrobblesResponse(
+data class MultiScrobbleResponse(
     @Json(name = "@attr") override val status: StatusResponse,
     val scrobble: List<ScrobbleResponse>
 ) : GeneralScrobbleResponse
@@ -27,4 +27,6 @@ data class ScrobbleResponse(
     val albumArtist: CorrectionResponse,
     val track: CorrectionResponse,
     val ignoredMessage: IgnoredResponse
-)
+) {
+    fun accepted() = ignoredMessage.code  == 0L
+}

--- a/libraries/submission/src/main/java/de/schnettler/scrobbler/submission/model/SubmissionFailureEntity.kt
+++ b/libraries/submission/src/main/java/de/schnettler/scrobbler/submission/model/SubmissionFailureEntity.kt
@@ -1,0 +1,11 @@
+package de.schnettler.scrobbler.submission.model
+
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+@Entity(tableName = "submission_failure")
+data class SubmissionFailureEntity(
+    @PrimaryKey val timestamp: Long,
+    val failureCode: Long,
+    val failureReason: String,
+)

--- a/libraries/submission/src/main/java/de/schnettler/scrobbler/submission/model/SubmissionResult.kt
+++ b/libraries/submission/src/main/java/de/schnettler/scrobbler/submission/model/SubmissionResult.kt
@@ -1,10 +1,6 @@
 package de.schnettler.scrobbler.submission.model
 
-import de.schnettler.lastfm.models.Errors
-
-data class SubmissionResult(
-    val accepted: List<ScrobbleResponse>,
-    val ignored: List<ScrobbleResponse>,
-    val errors: List<Errors>,
-    val exceptions: List<Throwable>
-)
+sealed class SubmissionResult {
+    data class Success(val accepted: List<ScrobbleResponse>, val ignored: List<ScrobbleResponse>) : SubmissionResult()
+    data class Error(val message: String, val recoverable: Boolean = false) : SubmissionResult()
+}

--- a/libraries/submission/src/main/java/de/schnettler/scrobbler/submission/model/SubmissionResults.kt
+++ b/libraries/submission/src/main/java/de/schnettler/scrobbler/submission/model/SubmissionResults.kt
@@ -1,0 +1,7 @@
+package de.schnettler.scrobbler.submission.model
+
+data class SubmissionResults(
+    val accepted: List<ScrobbleResponse>,
+    val ignored: List<ScrobbleResponse>,
+    val errors: List<SubmissionResult.Error>,
+)


### PR DESCRIPTION
This PR improves the handling of ignored scrobbles by doing the following:
- Don't try to submit ignored scrobbles more than once (-> mark them as failed locally)
- Show number of ignored scrobbles on the history screen
- Try to submit ignored scrobbles again after the user changed some metadata
- Add new red status indicator to ignored items in history list

Also refactor SubmissionRepository to improve scrobble submission logic and reuse same logic for scrobble submission from localViewModel.